### PR TITLE
Eris/remove email from employer base scheme

### DIFF
--- a/server/app/schemas/employer.py
+++ b/server/app/schemas/employer.py
@@ -14,7 +14,6 @@ class EmployerBase(BaseModel):
     location: Optional[str] = None
     country: Optional[str] = None
     tel: Optional[str] = None
-    email: Optional[str] = None
 
 class EmployerRead(EmployerBase):
     id: int


### PR DESCRIPTION
I removed "email" attribute from EmployerBase scheme, because it's necessary since we have that object on user scheme. 
Note: User scheme include (inherit) EmployerScheme.