### PR TITLE
Eris/feature/refactor-me-deactivate-route-add

### DIFF
--- a/server/app/routers/me.py
+++ b/server/app/routers/me.py
@@ -1,61 +1,30 @@
 from typing import Optional
 from fastapi import APIRouter, Depends, HTTPException
-from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 from app.core import get_db
-from app.schemas.user import ResetPasswordRequest, UserRead, UserUpdate
-from app.models.user import User
-from app.utils.auth import get_current_user, hash_password, verify_password
+from app.schemas.user import ResetPasswordRequest, UserActiveStatus, UserRead, ExtendedUserRead
 from app.schemas.candidate import CandidateUpdate
 from app.schemas.employer import EmployerUpdate
-from app.models.skill import Skill
+from app.models.user import User
+from app.utils.auth import get_current_user
+from app.services import me as me_service
 
 router = APIRouter()
 
-@router.get("", response_model=UserRead)
+@router.get("", response_model=ExtendedUserRead)
 async def read_me(current_user: User = Depends(get_current_user)):
-    return current_user
+    return await me_service.read_me(current_user)
 
 
-@router.put("", response_model=UserRead)
+@router.put("", response_model=ExtendedUserRead)
 async def update_me(
     db: AsyncSession = Depends(get_db),
     current_user: User = Depends(get_current_user),
     candidate_data: Optional[CandidateUpdate] = None,
     employer_data: Optional[EmployerUpdate] = None,
 ):
-    if current_user.role.name == "candidate":
-        if not candidate_data:
-            raise HTTPException(status_code=400, detail="Candidate data required")
-        candidate = current_user.candidate
-        for field, value in candidate_data.model_dump(exclude_unset=True).items():
-            setattr(candidate, field, value)
+    return await me_service.update_user(db, current_user, candidate_data, employer_data)
 
-
-        if candidate_data.skills is not None:
-            result = await db.execute(
-                select(Skill).where(Skill.id.in_(candidate_data.skills))
-            )
-            skill_objs = result.scalars().all()
-            candidate.skills = skill_objs
-
-        await db.commit()
-        await db.refresh(candidate)
-        return current_user
-
-    elif current_user.role.name == "employer":
-        if not employer_data:
-            raise HTTPException(status_code=400, detail="Employer data required")
-        employer = current_user.employer
-        for field, value in employer_data.model_dump(exclude_unset=True).items():
-            setattr(employer, field, value)
-
-        await db.commit()
-        await db.refresh(employer)
-        return current_user
-
-    else:
-        raise HTTPException(status_code=403, detail="Role not allowed for update")
 
 @router.put("/reset-password")
 async def reset_password(
@@ -63,10 +32,13 @@ async def reset_password(
     db: AsyncSession = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
-    if not verify_password(data.old_password, current_user.hashed_password):
-        raise HTTPException(status_code=400, detail="Old password is incorrect")
+    return await me_service.reset_password(db, current_user, data)
 
-    current_user.hashed_password = hash_password(data.new_password)
 
-    await db.commit()
-    return {"message": "Password updated successfully"}
+@router.put("/active", response_model=UserActiveStatus)
+async def set_active_status(
+    data: UserActiveStatus,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    return await me_service.set_active_status(db, current_user, data)

--- a/server/app/schemas/user.py
+++ b/server/app/schemas/user.py
@@ -2,8 +2,8 @@ from datetime import datetime
 from typing import Optional
 from pydantic import BaseModel, EmailStr, Field
 from app.schemas.role import RoleRead
-from app.schemas.candidate import CandidateBase
-from app.schemas.employer import EmployerBase
+from app.schemas.candidate import CandidateBase, CandidateRead
+from app.schemas.employer import EmployerBase, EmployerRead
 
 class UserBase(BaseModel):
     email: EmailStr
@@ -21,6 +21,13 @@ class UserRead(BaseModel):
     updated_at: datetime
     role: RoleRead
     is_verified: bool
+
+class ExtendedUserRead(UserRead):
+    employer: EmployerRead | None = None
+    candidate: CandidateRead | None = None
+
+class UserActiveStatus(BaseModel):
+    is_active: bool
 
 class UserCreate(BaseModel):
     password: str

--- a/server/app/services/me.py
+++ b/server/app/services/me.py
@@ -1,0 +1,81 @@
+from typing import Optional
+from fastapi import HTTPException
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.user import User
+from app.models.skill import Skill
+from app.schemas.user import ResetPasswordRequest, UserActiveStatus
+from app.schemas.candidate import CandidateUpdate
+from app.schemas.employer import EmployerUpdate
+from app.utils.auth import hash_password, verify_password
+
+
+async def read_me(current_user: User) -> User:
+    return current_user
+
+
+async def update_user(
+    db: AsyncSession,
+    current_user: User,
+    candidate_data: Optional[CandidateUpdate],
+    employer_data: Optional[EmployerUpdate],
+) -> User:
+    if current_user.role.name == "candidate":
+        if not candidate_data:
+            raise HTTPException(status_code=400, detail="Candidate data required")
+        candidate = current_user.candidate
+
+        for field, value in candidate_data.model_dump(exclude_unset=True).items():
+            if field == "skills":
+                continue
+            setattr(candidate, field, value)
+
+        if candidate_data.skills is not None:
+            result = await db.execute(
+                select(Skill).where(Skill.id.in_(candidate_data.skills))
+            )
+            skill_objs = result.scalars().all()
+            candidate.skills = skill_objs
+
+        await db.commit()
+        await db.refresh(candidate)
+        return current_user
+
+    elif current_user.role.name == "employer":
+        if not employer_data:
+            raise HTTPException(status_code=400, detail="Employer data required")
+        employer = current_user.employer
+
+        for field, value in employer_data.model_dump(exclude_unset=True).items():
+            setattr(employer, field, value)
+
+        await db.commit()
+        await db.refresh(employer)
+        return current_user
+
+    else:
+        raise HTTPException(status_code=403, detail="Role not allowed for update")
+
+async def reset_password(
+    db: AsyncSession,
+    current_user: User,
+    data: ResetPasswordRequest,
+):
+    if not verify_password(data.old_password, current_user.hashed_password):
+        raise HTTPException(status_code=400, detail="Old password is incorrect")
+
+    current_user.hashed_password = hash_password(data.new_password)
+    await db.commit()
+    return {"message": "Password updated successfully"}
+
+
+async def set_active_status(
+    db: AsyncSession,
+    current_user: User,
+    data: UserActiveStatus,
+):
+    current_user.is_active = data.is_active
+    await db.commit()
+    await db.refresh(current_user)
+    return {"is_active": current_user.is_active}

--- a/server/app/utils/auth.py
+++ b/server/app/utils/auth.py
@@ -80,9 +80,6 @@ async def get_current_user(
         raise HTTPException(status_code=401, detail="User not found")
     if user.is_suspended:
         raise HTTPException(status_code=403, detail="Account suspended")
-    if not user.is_active:
-        raise HTTPException(status_code=403, detail="Account inactive")
-
     return user
 
 def require_roles(*allowed_roles: str):


### PR DESCRIPTION
In this PR I refactored the /me logic and added the deactivate/activate account route.

For the PUT /me route:

The request body is now documented in Swagger as if it accepts both candidate_data and employer_data.

This was the workaround after we tried using a discriminator with a union type, but Swagger did not render it correctly (it always showed only one role).

Important: even though Swagger shows both objects, from the client side we only send the one that matches the logged-in user’s role (candidates send candidate_data, employers send employer_data). The other one can be ignored.

This keeps the update logic consistent, avoids discriminator issues, and still allows us to clearly separate fields per role.